### PR TITLE
chore: peg minimum Node.js version to >=16.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is a working prototype of a basic web3-native social application. Features 
 
 - Permanent post storage (Arweave)
 - Editable, self-sovereign user profiles (Ceramic [self.id](https://self.id/))
-- [GraphQL queries](https://gql-guide.vercel.app/) 
+- [GraphQL queries](https://gql-guide.vercel.app/)
 - Filtering at protocol level (not on client)
 - Fund and check balance of Bundlr with Matic on Polygon
 - [Pagination](https://gql-guide.vercel.app/#pagination) can also be implemented fairly easily with a few extra lines of code at protocol level
@@ -48,6 +48,10 @@ npm install
 3. Run the app
 
 ```sh
+yarn dev
+
+# or
+
 npm run dev
 ```
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "start": "next start",
     "lint": "next lint"
   },
+  "engines": {
+    "node": ">=16.0.0"
+  },
   "dependencies": {
     "3id-did-provider": "^1.1.1",
     "@3id/connect": "^0.2.5",


### PR DESCRIPTION
Initial installation went through a few different loops of needing a newer version of Node- looks like 16 is what is the minimum required
<img width="1252" alt="Screen Shot 2022-04-17 at 6 37 03 PM" src="https://user-images.githubusercontent.com/4411839/163742263-a6025130-02f9-475e-9729-9facb3b9f130.png">
<img width="1239" alt="Screen Shot 2022-04-17 at 6 37 43 PM" src="https://user-images.githubusercontent.com/4411839/163742306-debf529d-b7c8-49c1-88cc-0d7f3e4b8a3e.png">
<img width="1259" alt="Screen Shot 2022-04-17 at 6 36 54 PM" src="https://user-images.githubusercontent.com/4411839/163742312-edb87a31-5eb1-4514-b4f2-d49af7131b6b.png">
<img width="1251" alt="Screen Shot 2022-04-17 at 6 36 48 PM" src="https://user-images.githubusercontent.com/4411839/163742331-d3b2f250-82db-4048-b7e2-4160f2c655f7.png">

